### PR TITLE
Add account::manage_ssh_keys define to handle sshkeys parameter

### DIFF
--- a/manifests/manage_ssh_keys.pp
+++ b/manifests/manage_ssh_keys.pp
@@ -1,0 +1,24 @@
+#
+# manage ssh keys for user
+#
+define account::manage_ssh_keys(
+  $user,
+  $key_file,
+  $ensure = present,
+) {
+
+  $key_array   = split($name, ' ')
+  $key_type    = $key_array[0] # ssh-rsa|ssh-dss
+  $key_data    = $key_array[1] # Actual public key data
+  $key_comment = $key_array[2] # Comment/name for key
+
+  ssh_authorized_key {
+    "${user}_${key_type}_${key_comment}":
+      ensure => $ensure,
+      user   => $user,
+      name   => $key_comment,
+      key    => $key_data,
+      type   => $key_type,
+      target => $key_file
+  }
+}


### PR DESCRIPTION
To allow for more than one SSH key per user account need to be able to
pass an array of keys so use manage_ssh_keys to handle the SSH authorized
keys file. Revised ssh_key to use manage_ssh_keys as well for consistency
and adhere to DRY principle.

Usage:

``` YAML
accounts:
  jdoe:
    sshkeys:
      - ssh-rsa AAAAB3...26598fe jdoe@example.org
      - ssh-dss AAAAB3...Sr7GVVk jdoe@example.com
```
