### PR TITLE
Update README.mkd

### DIFF
--- a/README.mkd
+++ b/README.mkd
@@ -58,7 +58,7 @@ For use with [hiera](http://docs.puppetlabs.com/#hierahiera1), one could define 
 
 And then use the [create_resources function](http://docs.puppetlabs.com/references/latest/function.html#createresources) in a puppet manifest:
 
-    $accounts = hiera('accounts')
+    $accounts = hiera_hash('accounts')
     create_resources('account', $accounts)
 
 ## Feedback


### PR DESCRIPTION
I think it would be a good idea to demonstrate usage of `hiera_hash()` (rather than `hiera()`) which is very useful when you are using multiple hiera YAMLs.

For example, in many organizations you may have a `common.yaml` that includes all sysadmin users.  And another `environment/dev.yaml` that includes additional users from the developer team. Using `hiera_hash()` would combine both YAML's.
