### PR TITLE
Solaris compatibility and "root" user compatibility

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -99,14 +99,14 @@ define account(
 ) {
 
   if $home_dir == undef {
-    if $username == "root" {
-       case $operatingsystem {
-       'Solaris': { $home_dir_real = "/" }
-       default:   { $home_dir_real = "/root" }
+    if $username == 'root' {
+       case $::operatingsystem {
+       'Solaris': { $home_dir_real = '/' }
+       default:   { $home_dir_real = '/root' }
        }
     }
     else {
-       case $operatingsystem {
+       case $::operatingsystem {
        'Solaris': { $home_dir_real = "/export/home/${username}" }
        default:   { $home_dir_real = "/home/${username}" }
        }


### PR DESCRIPTION
This PR adds 2 improvements:
- Adds compatibility for Solaris (local users' homes are stored in `/export/home`)
- Considers the default path for "root" account is different than regular users. Previously, if the home dir was not specified, this module would have set the home dir to "`/home/root`" which is wrong and can break things. But now it sets it to "`/root`" (Linux, etc) or "`/`" (Solaris).

Let me know what you think!
