### PR TITLE
Only create the sshdir when an ssh key is provided

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -152,13 +152,13 @@ define account(
       $dir_ensure = directory
       $dir_owner  = $username
       $dir_group  = $primary_group
-      User[$title] -> File["${title}_home"] -> File["${title}_sshdir"]
+      User[$title] -> File["${title}_home"]
     }
     absent: {
       $dir_ensure = absent
       $dir_owner  = undef
       $dir_group  = undef
-      File["${title}_sshdir"] -> File["${title}_home"] -> User[$title]
+      File["${title}_home"] -> User[$title]
     }
     default: {
       err( "Invalid value given for ensure: ${ensure}. Must be one of present,absent." )
@@ -187,17 +187,20 @@ define account(
       path    => $home_dir_real,
       owner   => $dir_owner,
       group   => $dir_group,
-      mode    => $home_dir_perms;
-
-    "${title}_sshdir":
-      ensure  => $dir_ensure,
-      path    => "${home_dir_real}/.ssh",
-      owner   => $dir_owner,
-      group   => $dir_group,
-      mode    => '0700';
+      mode    => $home_dir_perms,
   }
 
   if $ssh_key != undef {
+    File["${title}_home"]->
+    file {
+      "${title}_sshdir":
+        ensure  => $dir_ensure,
+        path    => "${home_dir_real}/.ssh",
+        owner   => $dir_owner,
+        group   => $dir_group,
+        mode    => '0700',
+    }
+
     File["${title}_sshdir"]->
     ssh_authorized_key {
       $title:

--- a/spec/defines/account_spec.rb
+++ b/spec/defines/account_spec.rb
@@ -38,18 +38,11 @@ describe 'account' do
         'owner'   => title,
         'group'   => title,
         'mode'    => '0750',
-        'before'  => "File[#{title}_sshdir]",
       })
     end
 
     it do
-      should contain_file( "#{title}_sshdir" ).with({
-        'ensure'  => 'directory',
-        'path'    => "/home/#{title}/.ssh",
-        'owner'   => title,
-        'group'   => title,
-        'mode'    => '0700',
-      })
+      should_not contain_file( "#{title}_sshdir" )
     end
   end
 
@@ -65,6 +58,7 @@ describe 'account' do
       :uid            => 777,
       :allowdupe      => true,
       :groups         => [ 'sudo', 'users' ],
+      :ssh_key        => "foo",
     }}
 
     it do
@@ -91,10 +85,11 @@ describe 'account' do
 
     it do
       should contain_file( "#{title}_home" ).with({
-        'path'  => params[:home_dir],
-        'owner' => params[:username],
-        'group' => params[:username],
-        'mode'  => params[:home_dir_perms],
+        'path'   => params[:home_dir],
+        'owner'  => params[:username],
+        'group'  => params[:username],
+        'mode'   => params[:home_dir_perms],
+        'before' => "File[#{title}_sshdir]",
       })
     end
 
@@ -124,7 +119,7 @@ describe 'account' do
     end
 
     it do
-      should contain_file( "#{title}_sshdir" ).with({ 'group' => 'users' })
+      should_not contain_file( "#{title}_sshdir" )
     end
   end
 
@@ -145,7 +140,7 @@ describe 'account' do
     end
 
     it do
-      should contain_file( "#{title}_sshdir" ).with({ 'group' => params[:gid] })
+      should_not contain_file( "#{title}_sshdir" )
     end
   end
 end


### PR DESCRIPTION
This module creates the ~/.ssh dir even when an ssh key isn't provided. I'm using another module for ssh key management, and this module's .ssh dir File resource conflict with the same resource in that other module.

With this change, the ~/.ssh directory is only created when an ssh key is provided.
