### PR TITLE
Corrected symbolic link

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,1 +1,1 @@
-.travis/travis.yml
+.ci/travis.yml


### PR DESCRIPTION
The broken symbolic link causes rsync to throw an error when copying these files