### PR TITLE
Only create the sshdir when an ssh key is provided

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -160,13 +160,13 @@ define account(
       $dir_ensure = directory
       $dir_owner  = $username
       $dir_group  = $primary_group
-      User[$title] -> File["${title}_home"] -> File["${title}_sshdir"]
+      User[$title] -> File["${title}_home"]
     }
     absent: {
       $dir_ensure = absent
       $dir_owner  = undef
       $dir_group  = undef
-      File["${title}_sshdir"] -> File["${title}_home"] -> User[$title]
+      File["${title}_home"] -> User[$title]
     }
     default: {
       err( "Invalid value given for ensure: ${ensure}. Must be one of present,absent." )
@@ -196,18 +196,21 @@ define account(
       owner   => $dir_owner,
       group   => $dir_group,
       force   => $purge,
-      mode    => $home_dir_perms;
-
-    "${title}_sshdir":
-      ensure  => $dir_ensure,
-      path    => "${home_dir_real}/.ssh",
-      owner   => $dir_owner,
-      group   => $dir_group,
-      force   => $purge,
-      mode    => '0700';
+      mode    => $home_dir_perms,
   }
 
   if $ssh_key != undef {
+    File["${title}_home"]->
+    file {
+      "${title}_sshdir":
+        ensure  => $dir_ensure,
+        path    => "${home_dir_real}/.ssh",
+        owner   => $dir_owner,
+        group   => $dir_group,
+        force   => $purge,
+        mode    => '0700',
+    }
+
     File["${title}_sshdir"]->
     ssh_authorized_key {
       $title:

--- a/spec/defines/account_spec.rb
+++ b/spec/defines/account_spec.rb
@@ -38,20 +38,12 @@ describe 'account' do
         'owner'   => title,
         'group'   => title,
         'mode'    => '0750',
-        'before'  => ["File[#{title}_sshdir]"],
         'force'   => false,
       })
     end
 
     it do
-      should contain_file( "#{title}_sshdir" ).with({
-        'ensure'  => 'directory',
-        'path'    => "/home/#{title}/.ssh",
-        'owner'   => title,
-        'group'   => title,
-        'mode'    => '0700',
-        'force'   => false,
-      })
+      should_not contain_file( "#{title}_sshdir" )
     end
   end
 
@@ -68,6 +60,7 @@ describe 'account' do
       :allowdupe      => true,
       :purge          => true,
       :groups         => [ 'sudo', 'users' ],
+      :ssh_key        => 'foo',
     }}
 
     it do
@@ -94,11 +87,12 @@ describe 'account' do
 
     it do
       should contain_file( "#{title}_home" ).with({
-        'path'  => params[:home_dir],
-        'owner' => params[:username],
-        'group' => params[:username],
-        'mode'  => params[:home_dir_perms],
-        'force' => true,
+        'path'   => params[:home_dir],
+        'owner'  => params[:username],
+        'group'  => params[:username],
+        'mode'   => params[:home_dir_perms],
+        'before' => "File[#{title}_sshdir]",
+        'force'  => true,
       })
     end
 
@@ -129,7 +123,7 @@ describe 'account' do
     end
 
     it do
-      should contain_file( "#{title}_sshdir" ).with({ 'group' => 'users' })
+      should_not contain_file( "#{title}_sshdir" )
     end
   end
 
@@ -150,7 +144,7 @@ describe 'account' do
     end
 
     it do
-      should contain_file( "#{title}_sshdir" ).with({ 'group' => params[:gid] })
+      should_not contain_file( "#{title}_sshdir" )
     end
   end
 end


### PR DESCRIPTION
 This module creates the ~/.ssh directory whether it's needed or not. I'm using another module to manage ssh keys, and this module's File resource for the ~/.ssh directory conflicts with the same resource in the other module.

With this change, the ~/.ssh directory is only created when an ssh key is provided.
