### PR TITLE
Puppet 4.4 compilation fails due to use of type +

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -215,9 +215,9 @@ define account(
     validate_hash($ssh_keys)
 
     $defaults = {
-      ensure => $ensure,
-      type   => 'ssh-rsa',
-      user   => $username,
+      'ensure' => $ensure,
+      'type'   => 'ssh-rsa',
+      'user'   => $username,
     }
 
     create_resources('ssh_authorized_key', $ssh_keys, $defaults)


### PR DESCRIPTION
Quoted default key values to avoid Puppet interpreting the key as the reserved Puppet word 'type'.