### PR TITLE
Test fixes

### DIFF
--- a/.ci/Gemfile
+++ b/.ci/Gemfile
@@ -10,4 +10,7 @@ gem 'puppetlabs_spec_helper', '>= 0.1.0'
 if RUBY_VERSION >= '1.8.7' && RUBY_VERSION < '1.9'
   gem 'rake',  '~> 10.5.0'
   gem 'rspec', '~> 2.0'
+  gem 'json_pure', '~> 1.8'
+  gem 'json', '~> 1.8', '<=1.8.3'
+  gem 'semantic_puppet', '<= 0.1.3'
 end

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -191,20 +191,20 @@ define account(
 
   file {
     "${title}_home":
-      ensure  => $dir_ensure,
-      path    => $home_dir_real,
-      owner   => $dir_owner,
-      group   => $dir_group,
-      force   => $purge,
-      mode    => $home_dir_perms;
+      ensure => $dir_ensure,
+      path   => $home_dir_real,
+      owner  => $dir_owner,
+      group  => $dir_group,
+      force  => $purge,
+      mode   => $home_dir_perms;
 
     "${title}_sshdir":
-      ensure  => $dir_ensure,
-      path    => "${home_dir_real}/.ssh",
-      owner   => $dir_owner,
-      group   => $dir_group,
-      force   => $purge,
-      mode    => '0700';
+      ensure => $dir_ensure,
+      path   => "${home_dir_real}/.ssh",
+      owner  => $dir_owner,
+      group  => $dir_group,
+      force  => $purge,
+      mode   => '0700';
   }
 
   if $ssh_key != undef {

--- a/spec/defines/account_spec.rb
+++ b/spec/defines/account_spec.rb
@@ -1,6 +1,13 @@
 require 'spec_helper'
 
 describe 'account' do
+
+  let :facts do
+    {
+      :operatingsystem => 'Debian'
+    }
+  end
+
   describe 'account with default values' do
     let( :title ) { 'user' }
 
@@ -154,4 +161,3 @@ describe 'account' do
     end
   end
 end
-


### PR DESCRIPTION
Some simple fixes to ensure the tests continue to pass:

- Several gems now need versions specifying for Ruby 1.8.7;
- Newer version of rspec-puppet need facts to be supplied in the spec;
- Whitespace adjustment prevents "WARNING: indentation of => is not properly aligned" errors from lint.

Only minor changes, but I thought you might appreciate the PR.